### PR TITLE
ブラウザバック禁止/リロード警告/リロード時の遷移/Taptostart

### DIFF
--- a/public/javascripts/script.js
+++ b/public/javascripts/script.js
@@ -1,3 +1,21 @@
+//ブラウザバック禁止
+history.pushState(null, null, location.href);
+window.addEventListener('popstate', (e) => {
+  history.go(1);
+});
+//リロード前の警告
+window.addEventListener('beforeunload', function(e){
+  /** 更新される直前の処理 */
+  console.log('beforeunload');
+  var message = '本当に更新してよろしいですか？';
+  e.returnValue = message;
+  return message;
+});
+//リロードされたとき、現在の値を持ったままキャラクター選択画面に遷移する
+if(window.performance.navigation.type === 1){
+  window.location.href = document.URL.replace('alien','waiting');
+}
+
 // Peerモデルを変更
 const Peer = window.Peer;
 (async function main() {

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -2,6 +2,7 @@
 body {
    margin: 0; 
    background-color: #3B1D70;
+   background-image: url('https://kg-alien.s3-ap-northeast-1.amazonaws.com/%E9%80%9A%E8%A9%B1%E8%83%8C%E6%99%AF%E7%B4%A0%E6%9D%90.svg');
 }
 
 video {
@@ -20,21 +21,21 @@ video {
   overflow: scroll;
   z-index: 100;
   background: #3B1D70;
+  background-image: url('https://kg-alien.s3-ap-northeast-1.amazonaws.com/%E9%80%9A%E8%A9%B1%E8%83%8C%E6%99%AF%E7%B4%A0%E6%9D%90.svg');
 }
 
 img#top_wait{
   width: auto;
-  height: 40vh;
+  height: 25vh;
   display: block;
   margin: auto;
-  margin-top: 10vh;
+  margin-top: 30vh;
   
 }
 
 div#title_wait{
-  margin-top: 5vh;
   font-family: 'Megrim', cursive;
-  font-size: 11vh;
+  font-size: 8vh;
   font-style: normal;
   color: #DB560E;
   text-align: center;
@@ -43,8 +44,8 @@ div#title_wait{
 p#wait_message{
   text-align: center;
   color: #e5e5e5;
-  font-size: 5vh;
-  margin-top: 5vh;
+  font-size: 3vh;
+  margin: 0;
 }
 
 /* 時間設定デザイン  時間延長関連のコード*/
@@ -110,10 +111,8 @@ button#test1:hover {
   grid-template-columns: 40vw 40vw;
   grid-auto-rows: 40vh;
 
-  column-gap: 4vh;
-  row-gap: 4vh;
-  
-  background-color: #3B1D70;
+  column-gap: 2vh;
+  row-gap: 2vh;
   justify-content: center;
 }
 

--- a/views/index.jade
+++ b/views/index.jade
@@ -22,7 +22,7 @@ head
       |       
       #title_wait ALIEN
       |       
-      p#wait_message Tap to start video call
+      p#wait_message 画面をクリックすると通話を開始します
     |   
     .container
       #remote-streams


### PR DESCRIPTION
ブラウザバック(戻る)ができないように変更
リロードするとき警告を表示
リロードしたときroomid等データを引き継いだままキャラクター選択に遷移
Taptostartのデザイン変更